### PR TITLE
Request for updating 'AWS ACM'

### DIFF
--- a/docs/enterprise/multi-tenancy.mdx
+++ b/docs/enterprise/multi-tenancy.mdx
@@ -34,9 +34,9 @@ There are several steps involved in enabling multi-tenancy:
 - adding an environment variable used at build time
 - importing a Tenant Manager module to be able to manage tenants
 - adding a Lambda@Edge function to the Pulumi configuration
-- creating a certificate in AWS ACM, and linking it with CloudFront distribution
+- creating a certificate in AWS Certificate Manager (ACM), and linking it with CloudFront distribution
 
-Cloudfront will be used for TLS termination, and AWS ACM for certificate management. Customers may use other 3rd party CDNs for those steps. If that’s the case, please get in touch so we can support you through the setup.
+Cloudfront will be used for TLS termination, and ACM for certificate management. Customers may use other 3rd party CDNs for those steps. If that’s the case, please get in touch so we can support you through the setup.
 
 The following sections guide you through the process in a step-by-step manner.
 
@@ -115,9 +115,9 @@ WEBINY_MULTI_TENANCY=true
 
 This variable will be picked up by the build process for both the API functions, as well as React applications, and multi-tenancy logic will be enabled in the applicable apps.
 
-## 5) Create a Certificate in AWS ACM
+## 5) Create a Certificate in ACM
 
-Before we modify the infrastructure setup, and deploy the project, we'll need to have a valid certificate in AWS ACM. Go to https://console.aws.amazon.com/acm/home?region=us-east-1#/certificates/request and request a new certificate, or import an existing one.
+Before we modify the infrastructure setup, and deploy the project, we'll need to have a valid certificate in ACM. Go to https://console.aws.amazon.com/acm/home?region=us-east-1#/certificates/request and request a new certificate, or import an existing one.
 
 Once the domains in the certificate are verified, we can proceed to the Pulumi configuration. For more information on creating certificates and validating hostnames, please go to [What Is AWS Certificate Manager? - AWS Certificate Manager](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html)
 


### PR DESCRIPTION
When looking into the Vale output list of errors, I saw instances of AWS ACM. As per Amazon, it is AWS Certificate Manager (ACM) or just ACM, and not AWS ACM. If this is correct, I can update to AWS Certificate Manager (ACM) for the first occurrence, and ACM in subsequent instances (two or three of them). 

Reference: https://aws.amazon.com/certificate-manager/getting-started/

## Short Description
<!--- Shortly describe what this PR introduces. -->
<!--- For help on writing docs, visit https://docs.webiny.com/docs/contributing/documentation -->

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->
- [A change on X page](#)
- [Update list of libraries](#)
- [A new diagram with updated resources](#)

## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [ ] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
N/A
