### PR TITLE
Request to update broken link

### DIFF
--- a/docs/key-topics/security-framework/react-security.mdx
+++ b/docs/key-topics/security-framework/react-security.mdx
@@ -36,9 +36,9 @@ Let's use the following diagram to analyze the order of operations that are goin
   alt="React Authentication and Authorization using Webiny Security Framework"
 />
 
-Once your application has started, it will render a login form (this can be your custom form or the one provided by your IdP's React SDK). A user submits his credentials to the IdP (`1`). If credentials are valid, IdP will return some basic identity information and a JWT token (`2`).
+Once your application has started, it will render a login form (this can be your custom form or the one provided by your IdP's React SDK). A user submits their credentials to the IdP (`1`). If credentials are valid, IdP will return some basic identity information and a JSON Web Token (JWT) (`2`).
 
-Now that you want to communicate with the Webiny API, you will attach that JWT token to every request you make (`3`). The Webiny API will then run the authentication process (`4`) described in the [API Security](/docs/key-topics/security-framework/api-security) article, and verify the JWT token (remember, how you implement your authentication plugin is up to you).
+Now that you want to communicate with the Webiny API, you will attach that JWT to every request you make (`3`). The Webiny API will then run the authentication process (`4`) described in the [API Security](/docs/key-topics/security-framework/api-security) article, and verify the JWT (remember, how you implement your authentication plugin is up to you).
 
 If the identity is valid and is authorized to perform the requested operation, the React application will receive the expected response from the API.
 
@@ -50,7 +50,7 @@ Once you've obtained the identity information from your IdP, you only know _who_
 
 So how do we fetch all that information?
 
-In the Admin Area application, that ships with the default Webiny project, we solve this problem by exposing a `login` GraphQL mutation. That mutation is responsible for returning user's information based on the identity obtained in the authentication process (using the JWT token). It's not a traditional login API call where you specify a username and a password. It's more of a helper that is used to provide application-related information and permissions back to the React application.
+In the Admin Area application, that ships with the default Webiny project, we solve this problem by exposing a `login` GraphQL mutation. That mutation is responsible for returning user's information based on the identity obtained in the authentication process (using the JWT). It's not a traditional login API call where you specify a username and a password. It's more of a helper that is used to provide application-related information and permissions back to the React application.
 
 :::info
 
@@ -89,7 +89,7 @@ interface SecurityContextValue {
 
 The way SecurityProvider is supposed to be used is, you mount it as a parent of the component that's doing actual authentication in your application. Then, once you've logged in and obtained user information, you use the `setIdentity` method to set the identity information. That way, the rest of the application becomes immediately aware of the identity/user information and will rerender accordingly.
 
-An example of this can be found on our Github, in the [app-plugin-security-cognito](https://github.com/webiny/webiny-js/blob/next/packages/app-plugin-security-cognito/src/cognito/Authenticator.ts#L111) package.
+An example of this can be found on our GitHub, in the [app-plugin-security-cognito](https://github.com/webiny/webiny-js/blob/next/packages/app-plugin-security-cognito/src/cognito/Authenticator.ts#L111) package.
 
 ## Performing Authorization
 
@@ -115,4 +115,4 @@ export default () => {
 
 React applications load user permissions from the API, meaning they share the same permission objects. Handling of login is the responsibility of each individual React application and can be implemented in a number of ways, depending on your project requirements.
 
-The only requirement from the Webiny API is that you provide the necessary plugins to authenticate your JWT token and load identity's permissions.
+The only requirement from the Webiny API is that you provide the necessary plugins to authenticate your JWT and load identity's permissions.


### PR DESCRIPTION
In this page, the app-plugin-security-cognito package link does not work. The correct link has to replace the existing https://github.com/webiny/webiny-js/blob/next/packages/app-plugin-security-cognito/src/cognito/Authenticator.ts#L111.

## Short Description
<!--- Shortly describe what this PR introduces. -->
<!--- For help on writing docs, visit https://docs.webiny.com/docs/contributing/documentation -->

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->
- [A change on X page](#)
- [Update list of libraries](#)
- [A new diagram with updated resources](#)

## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [ ] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
N/A
