### PR TITLE
Request - Update Dependabot link?

### DIFF
--- a/docs/webiny-overview/security.mdx
+++ b/docs/webiny-overview/security.mdx
@@ -48,7 +48,7 @@ To learn more about Webiny's architecture, check out [this article](/docs/key-to
 
 The serverless services Webiny uses as part of its architecture are fault-tolerant by design. The only exception is Elasticsearch. In the Webiny production deployment stack, Elasticsearch is automatically deployed in multiple AZs, making it highly-available. Any public access, in both VPC and non-VPC deployment is restricted.
 
-:::info Update coming soon
+:::info Update coming soon 
 
 We're soon to release an update that allows you to use different databases to replace Elasticsearch.
 


### PR DESCRIPTION
In the Codebase section, https://dependabot.com gets redirected to the GitHub homepage, https://github.com. Should we rather give a link to the GitHub page of Dependabot, https://github.com/dependabot? 

Based on your suggestion, I will update the page (or let it remain as it is now).

## Short Description
<!--- Shortly describe what this PR introduces. -->
<!--- For help on writing docs, visit https://docs.webiny.com/docs/contributing/documentation -->

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->
- [A change on X page](#)
- [Update list of libraries](#)
- [A new diagram with updated resources](#)

## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [ ] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
N/A
