### PR TITLE
Request for updating .json path (If applicable)

### DIFF
--- a/docs/how-to-guides/use-watch-command.mdx
+++ b/docs/how-to-guides/use-watch-command.mdx
@@ -195,7 +195,7 @@ The automatic redeployments feature is not that useful when doing frontend devel
 
 This feature really shines when talking about backend (serverless) development, because all of the changes you make locally in your code are immediately reflected in a remote cloud environment.
 
-## Troubleshooting
+## Troubleshooting 
 
 #### I'm on Windows, using GitBash, and my screen looks completely broken.
 

--- a/docs/how-to-guides/use-watch-command.mdx
+++ b/docs/how-to-guides/use-watch-command.mdx
@@ -195,7 +195,7 @@ The automatic redeployments feature is not that useful when doing frontend devel
 
 This feature really shines when talking about backend (serverless) development, because all of the changes you make locally in your code are immediately reflected in a remote cloud environment.
 
-## Troubleshooting 
+## Troubleshooting
 
 #### I'm on Windows, using GitBash, and my screen looks completely broken.
 

--- a/docs/how-to-guides/use-watch-command.mdx
+++ b/docs/how-to-guides/use-watch-command.mdx
@@ -199,7 +199,7 @@ This feature really shines when talking about backend (serverless) development, 
 
 #### I'm on Windows, using GitBash, and my screen looks completely broken.
 
-If you're using [GitBash](https://www.atlassian.com/git/tutorials/git-bash), then you'll have to update it to at least to version `2.27.0`, as this version introduces the support for pseudo consoles.
+If you're using [Git Bash](https://www.atlassian.com/git/tutorials/git-bash), then you'll have to update it to at least to version `2.27.0`, as this version introduces the support for pseudo consoles.
 
 <CenteredImage alt="Enable Support For Pseudo Consoles" src={pseudoConsoles} />
 


### PR DESCRIPTION
In the TIP, the package.json locations display a 404 error for me. Either I don't have rights to access the files, or the path is not working. If it is the latter, please provide the correct paths, and I will update accordingly.

Location/path:
https://github.com/webiny/webiny-js/blob/next/packages/cwp-template-aws/template/api/code/graphql/package.json#L2 
https://github.com/webiny/webiny-js/blob/next/packages/cwp-template-aws/template/api/code/headlessCMS/package.json#L2

## Short Description
<!--- Shortly describe what this PR introduces. -->
<!--- For help on writing docs, visit https://docs.webiny.com/docs/contributing/documentation -->

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->
- [A change on X page](#)
- [Update list of libraries](#)
- [A new diagram with updated resources](#)

## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [ ] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
N/A
