### PR TITLE
Request to update 'Extend GraphQL API' path

### DIFF
--- a/docs/tutorials/create-custom-application/getting-started.mdx
+++ b/docs/tutorials/create-custom-application/getting-started.mdx
@@ -37,7 +37,7 @@ The best way to start building a new custom application would be to use the [Ful
 
 ### GraphQL API
 
-A new GraphQL API created within a new [project application](/docs/key-topics/project-organization/project-applications-and-packages) in our Webiny project (more information below). Once deployed, we will use the [Extend GraphQL API](https://www.webiny.com/docs/how-to-guides/scaffolding/extend-graphql-api/) scaffold to extend it, meaning, create new GraphQL types, queries, and mutations.
+A new GraphQL API created within a new [project application](/docs/key-topics/project-organization/project-applications-and-packages) in our Webiny project (more information below). Once deployed, we will use the [Extend GraphQL API](/docs/how-to-guides/scaffolding/extend-graphql-api/) scaffold to extend it, meaning, create new GraphQL types, queries, and mutations.
 
 Speaking of deployment, note that we'll need to deploy the newly created GraphQL API before jumping to React application development, simply because the React application relies on it. This is also something the [Full Stack Application](/docs/how-to-guides/scaffolding/full-stack-application) scaffold will warn us about, and will offer to do it for us.
 

--- a/docs/tutorials/create-custom-application/getting-started.mdx
+++ b/docs/tutorials/create-custom-application/getting-started.mdx
@@ -37,7 +37,7 @@ The best way to start building a new custom application would be to use the [Ful
 
 ### GraphQL API
 
-A new GraphQL API created within a new [project application](/docs/key-topics/project-organization/project-applications-and-packages) in our Webiny project (more information below). Once deployed, we will use the [Extend GraphQL API](/docs/tutorials/extend-admin-area/introduction) scaffold to extend it, meaning, create new GraphQL types, queries, and mutations.
+A new GraphQL API created within a new [project application](/docs/key-topics/project-organization/project-applications-and-packages) in our Webiny project (more information below). Once deployed, we will use the [Extend GraphQL API](https://www.webiny.com/docs/how-to-guides/scaffolding/extend-graphql-api/) scaffold to extend it, meaning, create new GraphQL types, queries, and mutations.
 
 Speaking of deployment, note that we'll need to deploy the newly created GraphQL API before jumping to React application development, simply because the React application relies on it. This is also something the [Full Stack Application](/docs/how-to-guides/scaffolding/full-stack-application) scaffold will warn us about, and will offer to do it for us.
 


### PR DESCRIPTION
In the GraphQL API section, "Extend GraphQL API" links to https://www.webiny.com/docs/tutorials/extend-admin-area/introduction. I corrected the link to the 'Extend GraphQL API' topic (https://www.webiny.com/docs/how-to-guides/scaffolding/extend-graphql-api/). If my assumption is correct, I request you to accept this change.

## Short Description
<!--- Shortly describe what this PR introduces. -->
<!--- For help on writing docs, visit https://docs.webiny.com/docs/contributing/documentation -->

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->
- [A change on X page](#)
- [Update list of libraries](#)
- [A new diagram with updated resources](#)

## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [ ] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
N/A
