### PR TITLE
Request to fix links

### DIFF
--- a/docs/key-topics/ci-cd/testing.mdx
+++ b/docs/key-topics/ci-cd/testing.mdx
@@ -266,4 +266,4 @@ Essentially, you'd be copying all of the data, from different services, from one
 - copying data, in some cases, also includes copying of files, Cognito users, and more
 - we need to decide which data should be copied and whether it should be identical or modified in the process
 
-As you can see, a simple "copy all of the data" script can very quickly become a complex script that requires a lot of knowledge about the project itself and the specific requirements that are in front of you.
+As you can see, a simple "copy all of the data" script can very quickly become a complex script that requires a lot of knowledge about the project itself and the specific requirements that are in front of you. 


### PR DESCRIPTION
In the Mark Mission Critical Cloud Infrastructure Resources As Protected section, the default 'DynamoDB table' and the default 'Cognito User Pool' links do not work for me. If you provide the correct links, I will update them.

## Short Description
<!--- Shortly describe what this PR introduces. -->
<!--- For help on writing docs, visit https://docs.webiny.com/docs/contributing/documentation -->

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->
- [A change on X page](#)
- [Update list of libraries](#)
- [A new diagram with updated resources](#)

## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [ ] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
N/A
